### PR TITLE
Add support in primus non default pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ command help
       -o, --output <output>    Output file
       -t, --type <type>        Type of websocket server to bench(socket.io, engine.io, faye, primus, wamp). Default to socket.io
       -p, --transport <type>   Type of transport to websocket(engine.io, websockets, browserchannel, sockjs, socket.io). Default to websockets (Just for Primus)
+      -n, --pathname <type>    Pathname for primus configuration, default is '/primus'
       -k, --keep-alive         Keep alive connection
       -v, --verbose            Verbose Logging
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ program
   .option('-o, --output <output>', 'Output file')
   .option('-t, --type <type>', 'type of websocket server to bench(socket.io, engine.io, faye, primus, wamp). Default to io')
   .option('-p, --transport <type>', 'type of transport to websocket(engine.io, websockets, browserchannel, sockjs, socket.io). Default to websockets')
+  .option('-n, --pathname <type>', 'pathname for primus configuration, default is "/primus" ')
   .option('-k, --keep-alive', 'Keep alive connection')
   .option('-v, --verbose', 'Verbose Logging')
   .parse(process.argv);
@@ -74,7 +75,8 @@ var options = {
   type          : program.type,
   transport     : program.transport,
   keepAlive     : program.keepAlive,
-  verbose       : program.verbose
+  verbose       : program.verbose,
+  pathname      : program.pathname
 };
 
 if (program.verbose) {

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -36,7 +36,8 @@ Benchmark.prototype.launch = function (connectNumber, concurency, workerNumber, 
   for (var i = 0; i < workerNumber; i++) {
 
     this.workers[i] = cp.fork(__dirname + '/worker.js', [
-      this.server, this.options.generatorFile, this.options.type, this.options.transport, this.options.verbose
+      this.server, this.options.generatorFile, this.options.type, this.options.transport, this.options.verbose,
+      this.options.pathname
     ]);
 
     this.workers[i].on('message', this._onMessage.bind(this));

--- a/lib/workers/primusworker.js
+++ b/lib/workers/primusworker.js
@@ -7,7 +7,7 @@ var BaseWorker = require('./baseworker.js'),
   logger = require('../logger.js');
 
 // Create a primus instance in order to obtain the client constructor.
-var PrimusClient = new Primus(http.createServer(), {'transformer' : process.argv[5]}).Socket;
+var PrimusClient = new Primus(http.createServer(), {'transformer' : process.argv[5] , pathname: process.argv[7]}).Socket;
 
 var PrimusWorker = function (server, generator) {
   PrimusWorker.super_.apply(this, arguments);

--- a/test/functional/faye.js
+++ b/test/functional/faye.js
@@ -49,7 +49,7 @@ describe('Test Faye Benchmarking', function () {
     });
 
     it('should connect call reporter with 5 connection done', function (done) {
-      var stubReport = sinon.stub(testReporter, 'report', function (steps, monitor) {
+      var stubReport = sinon.stub(testReporter, 'report').callsFake(function (steps, monitor) {
         assert.equal(monitor.results.connection, 5);
         assert.equal(monitor.results.errors, 0);
         testReporter.report.restore();
@@ -62,7 +62,7 @@ describe('Test Faye Benchmarking', function () {
   });
   describe('Test without faye server', function () {
     it('should connect call reporter with 10 errors', function (done) {
-      var stubReport = sinon.stub(testReporter, 'report', function (steps, monitor) {
+      var stubReport = sinon.stub(testReporter, 'report').callsFake(function (steps, monitor) {
         assert.equal(monitor.results.connection, 0);
         assert.equal(monitor.results.errors, 10);
         testReporter.report.restore();


### PR DESCRIPTION
websocket-bench doesn't work when primus endpoint isn't default ("/primus"). 
primus supports configuring this using an argument that is passed to the client constructor.
This change add the option to configure non default primus pathname from the command line.