### PR TITLE
Deadloop fixing

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ if (!program.type) {
 }
 
 if (program.type === 'primus' && !program.transport) {
-  program.transPort = 'websockets';
+  program.transport = 'websockets';
 }
 
 logger.info('Launch bench with ' + program.amount + ' total connection, ' + program.concurency + ' concurent connection');

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ program
   .option('-t, --type <type>', 'type of websocket server to bench(socket.io, engine.io, faye, primus, wamp). Default to io')
   .option('-p, --transport <type>', 'type of transport to websocket(engine.io, websockets, browserchannel, sockjs, socket.io). Default to websockets')
   .option('-k, --keep-alive', 'Keep alive connection')
+  .option('-u, --timeout <n>', 'Set connection timeout. Default is 20000ms for socket.io', parseInt)
   .option('-v, --verbose', 'Verbose Logging')
   .parse(process.argv);
 
@@ -26,7 +27,6 @@ if (program.args.length < 1) {
 }
 
 var server = program.args[0];
-
 // Set default value
 if (!program.worker) {
   program.worker = 1;
@@ -64,6 +64,10 @@ if (program.type === 'primus' && !program.transport) {
   program.transport = 'websockets';
 }
 
+if (!program.timeout) {
+  program.timeout = 20000;
+}
+
 logger.info('Launch bench with ' + program.amount + ' total connection, ' + program.concurency + ' concurent connection');
 logger.info(program.message + ' message(s) send by client');
 logger.info(program.worker + ' worker(s)');
@@ -74,7 +78,8 @@ var options = {
   type          : program.type,
   transport     : program.transport,
   keepAlive     : program.keepAlive,
-  verbose       : program.verbose
+  verbose       : program.verbose,
+  timeout       : program.timeout
 };
 
 if (program.verbose) {

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -36,7 +36,7 @@ Benchmark.prototype.launch = function (connectNumber, concurency, workerNumber, 
   for (var i = 0; i < workerNumber; i++) {
 
     this.workers[i] = cp.fork(__dirname + '/worker.js', [
-      this.server, this.options.generatorFile, this.options.type, this.options.transport, this.options.verbose
+      this.server, this.options.generatorFile, this.options.type, this.options.transport, this.options.verbose, this.options.timeout
     ]);
 
     this.workers[i].on('message', this._onMessage.bind(this));

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -1,5 +1,9 @@
 /*global module, require*/
-
+logger = require('./logger.js');
+/**
+ * Define the counter limit
+ */
+var MAX_COUNTER = 0xFFFFFFFF;
 /**
  * Class for metrics
  */
@@ -16,22 +20,69 @@ var Monitor = function () {
   this.messageCounter = 0;
 
   this.counter = 0;
+  this.expectCounter = MAX_COUNTER;
+  this.verbose = false;
 };
 
+Monitor.prototype.setExpectCounter = function (expectCnt) {
+  this.expectCounter = expectCnt;
+};
+
+Monitor.prototype.setCounterNotifier = function (callback) {
+  this.cntNotifier = callback;
+};
+
+Monitor.prototype.reachCntLimit = function () {
+  if (this.counter >= this.expectCounter) {
+     if (this.verbose) {
+        logger.debug("Process " + process.pid + "reaches counter limit " + this.expectCounter);
+     }
+     if (this.cntNotifier) {
+        this.cntNotifier();
+     }
+     return true;
+  }
+  return false;
+};
+
+Monitor.prototype.isRunning = function () {
+  return !this.counter >= this.expectCounter;
+};
 
 Monitor.prototype.connection = function () {
-  this.results.connection++;
-  this.counter++;
+  if (!this.reachCntLimit()) {
+     this.results.connection++;
+     this.counter++;
+  } else {
+     if (this.verbose) {
+        logger.debug("Process " + process.pid + " in connection" +
+                     " reaches counter limit " + this.expectCounter);
+     }
+  }
 };
 
 Monitor.prototype.disconnection = function () {
-  this.results.disconnects++;
-  this.counter++;
+  if (!this.reachCntLimit()) {
+     this.results.disconnects++;
+     this.counter++;
+  } else {
+     if (this.verbose) {
+        logger.debug("Process " + process.pid + " in disconnection" +
+                     " reaches counter limit " + this.expectCounter);
+     }
+  }
 };
 
 Monitor.prototype.errors = function () {
-  this.results.errors++;
-  this.counter++;
+  if (!this.reachCntLimit()) {
+     this.results.errors++;
+     this.counter++;
+  } else {
+     if (this.verbose) {
+        logger.debug("Process " + process.pid + " in errors" +
+                     " reaches counter limit " + this.expectCounter);
+     }
+  }
 };
 
 Monitor.prototype.msgSend = function () {
@@ -55,7 +106,9 @@ Monitor.prototype.merge = function (monitor) {
   this.messageCounter += monitor.messageCounter;
   this.results.msgSend += monitor.results.msgSend;
   this.results.msgFailed += monitor.results.msgFailed;
-
+  if (this.expectCounter != MAX_COUNTER) {
+     this.expectCounter += monitor.expectCounter;
+  }
 };
 
 module.exports = Monitor;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -5,6 +5,7 @@ var logger = require('./logger'),
   generatorFile = process.argv[3],
   workerType = process.argv[4],
   verbose = process.argv[6] === 'true';
+  timeout = process.argv[7];
 
 if (!generatorFile || generatorFile === 'undefined') {
   generatorFile = './generator.js';
@@ -33,6 +34,7 @@ switch (workerType) {
     logger.error('error workerType ' + workerType);
 }
 
+process.env.TIMEOUT = timeout;
 var worker = new BenchmarkWorker(server, generator, verbose);
 
 process.on('message', function (message) {

--- a/lib/workers/baseworker.js
+++ b/lib/workers/baseworker.js
@@ -1,5 +1,4 @@
 /*global module, require*/
-
 var Monitor = require('../monitor.js'),
   logger = require('../logger.js');
 
@@ -16,6 +15,7 @@ var BaseWorker = function (server, generator, verbose) {
   this.clients = [];
   this.running = true;
   this.verbose = verbose;
+  this.testDoneCnt = 0;
 };
 
 /**
@@ -26,7 +26,13 @@ var BaseWorker = function (server, generator, verbose) {
 BaseWorker.prototype.launch = function (number, messageNumber) {
   var _this = this;
   var monitor = new Monitor();
-
+  monitor.setExpectCounter(number);
+  monitor.setCounterNotifier(function() {
+     this.running = false;
+     if (this.verbose) {
+        logger.debug("Monitor's counter notifier was invoked");
+     }
+  });
   for (var i = 0; i < number; i++) {
     this.createClient(function (err, client) {
       _this.clients.push(client);
@@ -37,6 +43,10 @@ BaseWorker.prototype.launch = function (number, messageNumber) {
   var testDone = function () {
     if (!_this._testLaunchDone(monitor, number, messageNumber)) {
       setTimeout(testDone, 500);
+      this.testDoneCnt++;
+      if (this.verbose) {
+         logger.debug("Process " + process.pid + " checks test DONE " + this.testDoneCnt);
+      }
     }
   };
 

--- a/lib/workers/socketioworker.js
+++ b/lib/workers/socketioworker.js
@@ -15,7 +15,8 @@ util.inherits(SocketIOWorker, BaseWorker);
 
 SocketIOWorker.prototype.createClient = function (callback) {
   var self = this;
-  var client = io.connect(this.server, { 'force new connection' : true});
+  var client = io.connect(this.server, { 'force new connection' : true,
+                                       timeout : process.env.TIMEOUT});
 
   client.on('connect', function () {
     callback(false, client);

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "socket.io-client": "~1.3.5",
+    "autobahn": "~0.9.5",
+    "cli-table": "^0.3.1",
+    "colors": "^0.6.2",
+    "commander": "^1.1.1",
     "engine.io-client": "~0.9.0",
-    "commander": "~1.1.1",
-    "colors": "~0.6",
-    "cli-table": "~0.3.0",
     "faye": "~0.8.9",
-    "winston": "~0.7.1",
-    "socket.io": "~1.3.5",
     "primus": "~1.5.2",
-    "autobahn": "~0.9.5"
+    "socket.io": "~1.3.5",
+    "socket.io-client": "^1.3.7",
+    "winston": "~0.7.1"
   },
   "devDependencies": {
     "chai": "~1.6.0",


### PR DESCRIPTION
There will be a dead loop if monitor.counter is larger than expected number in each process. This happens frequently because testDone was scheduled every 500ms and it will check whether monitor.counter == number. 

This fix records "expectCounter" in monitor itself, so when the expectCounter is equal to counter, monitor will stop increase counter and it also notify the worker through callback. This can avoid the dead loop.

In addition, allow users to specify a customized timeout.